### PR TITLE
Various fixes

### DIFF
--- a/cloudpg/src/main/java/io/clouditor/graph/passes/js/JSHttpPass.kt
+++ b/cloudpg/src/main/java/io/clouditor/graph/passes/js/JSHttpPass.kt
@@ -98,7 +98,9 @@ class JSHttpPass : Pass() {
     }
 
     private fun handleRequestUnpacking(fd: FunctionDeclaration, me: MemberExpression, e: HttpEndpoint) {
-        if (me.name == "body" && fd.parameters.first() == me.base) {
+        if (me.name == "body" &&
+                fd.parameters.first() == (me.base as DeclaredReferenceExpression).refersTo
+        ) {
             // set the DFG target of this call to the DFG target of our http endpoints
             me.nextDFG.forEach { e.addNextDFG(it) }
 

--- a/cloudpg/src/main/java/io/clouditor/graph/passes/js/JSHttpPass.kt
+++ b/cloudpg/src/main/java/io/clouditor/graph/passes/js/JSHttpPass.kt
@@ -3,7 +3,6 @@ package io.clouditor.graph.passes.js
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
-import de.fraunhofer.aisec.cpg.graph.declarations.ParamVariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
@@ -97,7 +96,11 @@ class JSHttpPass : Pass() {
         }
     }
 
-    private fun handleRequestUnpacking(fd: FunctionDeclaration, me: MemberExpression, e: HttpEndpoint) {
+    private fun handleRequestUnpacking(
+        fd: FunctionDeclaration,
+        me: MemberExpression,
+        e: HttpEndpoint
+    ) {
         if (me.name == "body" &&
                 fd.parameters.first() == (me.base as DeclaredReferenceExpression).refersTo
         ) {

--- a/cloudpg/src/main/java/io/clouditor/graph/passes/js/JSHttpPass.kt
+++ b/cloudpg/src/main/java/io/clouditor/graph/passes/js/JSHttpPass.kt
@@ -102,7 +102,7 @@ class JSHttpPass : Pass() {
         e: HttpEndpoint
     ) {
         if (me.name == "body" &&
-                fd.parameters.first() == (me.base as DeclaredReferenceExpression).refersTo
+                fd.parameters.first() == (me.base as? DeclaredReferenceExpression)?.refersTo
         ) {
             // set the DFG target of this call to the DFG target of our http endpoints
             me.nextDFG.forEach { e.addNextDFG(it) }

--- a/cloudpg/src/main/java/io/clouditor/graph/passes/python/FlaskPass.kt
+++ b/cloudpg/src/main/java/io/clouditor/graph/passes/python/FlaskPass.kt
@@ -94,8 +94,8 @@ class FlaskPass : Pass() {
             func.accept(
                 Strategy::AST_FORWARD,
                 object : IVisitor<Node?>() {
-                    fun visit(mce: MemberCallExpression) {
-                        handleRequestUnpacking(mce, endpoint)
+                    fun visit(me: MemberExpression) {
+                        handleRequestUnpacking(me, endpoint)
                     }
                 }
             )
@@ -106,10 +106,10 @@ class FlaskPass : Pass() {
         return null
     }
 
-    private fun handleRequestUnpacking(mce: MemberCallExpression, e: HttpEndpoint) {
-        if (mce.name == "json" && mce.base.name == "request") {
+    private fun handleRequestUnpacking(me: MemberExpression, e: HttpEndpoint) {
+        if (me.name == "json" && me.base.name == "request") {
             // set the DFG target of this call to the DFG target of our http endpoints
-            mce.nextDFG.forEach { e.addNextDFG(it) }
+            me.nextDFG.forEach { e.addNextDFG(it) }
 
             // TODO(oxisto): Once we update the ontology, we should also set this as the
             // "request_body" property of the http endpoint

--- a/cloudpg/src/main/java/io/clouditor/graph/passes/python/FlaskPass.kt
+++ b/cloudpg/src/main/java/io/clouditor/graph/passes/python/FlaskPass.kt
@@ -46,7 +46,7 @@ class FlaskPass : Pass() {
 
         if ((v.initializer as? CallExpression)?.name == "Flask") {
             // handle it as a request handler
-            val handler = HttpRequestHandler(app, mutableListOf(), "")
+            val handler = HttpRequestHandler(app, mutableListOf(), "/")
             handler.name = v.name
 
             app?.functionalities?.plusAssign(handler)


### PR DESCRIPTION
- Fix a wrong type in the JSHttpPass
- Fix the path of request handlers in Python: Previously it was given an empty path which results in erroneous urls, e.g. ...clouditor.io//api/v1/data/